### PR TITLE
[MOB-2153] Support Card.wallets

### DIFF
--- a/src/main/java/com/stripe/model/issuing/Card.java
+++ b/src/main/java/com/stripe/model/issuing/Card.java
@@ -164,6 +164,10 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
   @SerializedName("type")
   String type;
 
+  /** Wallets eligibility information. */
+  @SerializedName("wallets")
+  Wallets wallets;
+
   /** Get ID of expandable {@code replacedBy} object. */
   public String getReplacedBy() {
     return (this.replacedBy != null) ? this.replacedBy.getId() : null;
@@ -458,5 +462,33 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
       @SerializedName("interval")
       String interval;
     }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class Wallets extends StripeObject {
+    /** Apple Pay eligibility information. */
+    @SerializedName("apple_pay")
+    WalletEligibility applePay;
+
+    /** Google Pay eligibility information. */
+    @SerializedName("google_pay")
+    WalletEligibility googlePay;
+
+    /** Primary account ID which card was used with. */
+    @SerializedName("primary_account_identifier")
+    String primaryAccountIdentifier;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class WalletEligibility extends StripeObject {
+    @SerializedName("eligible")
+    Boolean eligible;
+
+    @SerializedName("ineligible_reason")
+    String ineligibleReason;
   }
 }

--- a/src/test/resources/api_fixtures/card.json
+++ b/src/test/resources/api_fixtures/card.json
@@ -22,5 +22,16 @@
   "metadata": {
   },
   "name": null,
-  "tokenization_method": null
+  "tokenization_method": null,
+  "wallets": {
+    "apple_pay": {
+      "eligible": true,
+      "ineligible_reason": null
+    },
+    "google_pay": {
+      "eligible": true,
+      "ineligible_reason": null
+    },
+    "primary_account_identifier": null
+  }
 }


### PR DESCRIPTION
Supporting new API field that is not present in the SDK yet. 

It will be used to check:
- if the card is eligible for Apple/Google Wallet
- if it was added to the wallet before, to decide whether to show Add To Wallet button in the client. The actual check is performed by the Native Stripe iOS library using the `primary_account_identifier` 

[MOB-2153](https://stepmobile.atlassian.net/browse/MOB-2153)

[digital-wallets-pai-integration.pdf](https://github.com/getstep/stripe-java/files/7455001/digital-wallets-pai-integration.pdf)




[MOB-2153]: https://stepmobile.atlassian.net/browse/MOB-2153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ