### PR TITLE
[BANK-3438] add verifiedByFraudChallenge

### DIFF
--- a/src/main/java/com/stripe/model/issuing/Authorization.java
+++ b/src/main/java/com/stripe/model/issuing/Authorization.java
@@ -242,6 +242,13 @@ public class Authorization extends ApiResource
   VerificationData verificationData;
 
   /**
+   * Whether the authorization bypassed fraud risk checks because the cardholder has previously completed
+   * a fraud challenge on a similar high-risk authorization from the same merchant.
+   */
+  @SerializedName("verified_by_fraud_challenge")
+  Boolean verifiedByFraudChallenge;
+
+  /**
    * The digital wallet used for this transaction. One of {@code apple_pay}, {@code google_pay}, or
    * {@code samsung_pay}. Will populate as {@code null} when no digital wallet was utilized.
    */


### PR DESCRIPTION
Adding `verified_by_fraud_challenge` field on `Authorization` class. Doc [here](https://docs.stripe.com/api/issuing/authorizations/object#issuing_authorization_object-verified_by_fraud_challenge)