### PR TITLE
add back in volumeDecimal

### DIFF
--- a/src/main/java/com/stripe/model/issuing/Transaction.java
+++ b/src/main/java/com/stripe/model/issuing/Transaction.java
@@ -763,6 +763,16 @@ public class Transaction extends ApiResource
        */
       @SerializedName("unit_cost_decimal")
       BigDecimal unitCostDecimal;
+
+      /**
+       * Deprecated: This was removed in version 26.0.0. We are adding it back in on our fork to maintain
+       * backwards compatibility while we upgrade our Stripe API versions.
+       *
+       * The volume of the fuel that was pumped, represented as a decimal string with at most 12
+       * decimal places.
+       */
+      @SerializedName("volume_decimal")
+      BigDecimal volumeDecimal;
     }
 
     @Getter


### PR DESCRIPTION
Stripe made a breaking change in latest major version (26) renaming `volumeDecimal` to `quantityDecimal` ([changelog](https://github.com/stripe/stripe-java/blob/master/CHANGELOG.md#2600---2024-06-24)). This PR adds back in `volumeDecimal` for now for backwards compatibility while we upgrade our Stripe API. We reference this field [here](https://github.com/getstep/server/blob/main/services/bank/stripe/service/src/main/kotlin/com/step/stripe/model/PurchaseDetailsEx.kt#L84) in server.