### PR TITLE
Add program to issuing Card object

### DIFF
--- a/src/main/java/com/stripe/model/issuing/Card.java
+++ b/src/main/java/com/stripe/model/issuing/Card.java
@@ -151,6 +151,10 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
   @SerializedName("pin")
   Pin pin;
 
+  /** The program that this card belongs to. */
+  @SerializedName("program")
+  String program;
+
   /** The latest card that replaces this card, if any. */
   @SerializedName("replaced_by")
   @Getter(lombok.AccessLevel.NONE)


### PR DESCRIPTION
https://docs.stripe.com/api/issuing/cards/object?api-version=2024-12-18.acacia#issuing_card_object-program

Since it's a preview feature, it's not available in the public SDK. Want to add the `program` field to the issuing `Card` object. Don't think we'll actually do anything with it other than check it in tests, but doesn't hurt to add it.