### PR TITLE
Add type to Stripe Authorization object

### DIFF
--- a/src/main/java/com/stripe/model/issuing/Authorization.java
+++ b/src/main/java/com/stripe/model/issuing/Authorization.java
@@ -250,6 +250,14 @@ public class Authorization extends ApiResource
   @SerializedName("treasury")
   Treasury treasury;
 
+  /**
+   * The type of the authorization, whether it is for a payment or another type.
+   *
+   * One of {@payment original_credit} or {@code payment}.
+   */
+  @SerializedName("type")
+  String type;
+
   @SerializedName("verification_data")
   VerificationData verificationData;
 


### PR DESCRIPTION
https://docs.stripe.com/api/issuing/authorizations/object?api-version=2025-03-31.basil#issuing_authorization_object-type

Adding `type` field to `Authorization` object to be used for distinguishing OCTs from payments.