### PR TITLE
Fix typo in type field doc

### DIFF
--- a/src/main/java/com/stripe/model/issuing/Authorization.java
+++ b/src/main/java/com/stripe/model/issuing/Authorization.java
@@ -253,7 +253,7 @@ public class Authorization extends ApiResource
   /**
    * The type of the authorization, whether it is for a payment or another type.
    *
-   * One of {@payment original_credit} or {@code payment}.
+   * One of {@code original_credit} or {@code payment}.
    */
   @SerializedName("type")
   String type;


### PR DESCRIPTION
Typo in previous [PR](https://github.com/getstep/stripe-java/pull/38) which is preventing building of project with error: 

```[InvalidInlineTag] Tag name `payment` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.```